### PR TITLE
Fix package name for case-sensitive filesystems

### DIFF
--- a/src/shared/lib/json-helpers.ts
+++ b/src/shared/lib/json-helpers.ts
@@ -1,6 +1,6 @@
 import { JsonValidatorModifier } from "../models/index";
 import * as fs from "fs-extra";
-import * as Ajv from "Ajv";
+import * as Ajv from "ajv";
 import * as _ from "lodash";
 
 export function readJson<valueType>(filename: string, fallbackValue: valueType, segments?: string[]) {


### PR DESCRIPTION
On a case-sensitive filesystem (in this case, Ext4 under Fedora 26), attempting `npm run watch:main` resulted in the following error: 

```
ERROR in [at-loader] ./src/shared/lib/json-helpers.ts:3:22 
    TS2307: Cannot find module 'Ajv'.
```

...since the `import * as Ajv from "Ajv"` was failing.

This fixes the issue.