### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Visit [Steam ROM Manager](https://frogthefrog.github.io/steam-rom-manager)'s git
 
 # For developers
 
-[![Build Status](https://travis-ci.org/FrogTheFrog/steam-rom-manager.svg?branch=v2.2.5)](https://travis-ci.org/FrogTheFrog/steam-rom-manager)
+[![Build Status](https://travis-ci.org/doZennn/steam-rom-manager.svg)](https://travis-ci.org/doZennn/steam-rom-manager)
 
 To compile this app, you'll need the latest `Node.js` and `npm`. Every script will need to be run from project directory.
 


### PR DESCRIPTION
Noticed the build status badge had outdated links, and was always showing the 2.2.5 branch status instead of master.