### PR TITLE
Add DuckStation & DuckStation RetroArch presets

### DIFF
--- a/files/presets/Sony PlayStation.json
+++ b/files/presets/Sony PlayStation.json
@@ -106,4 +106,112 @@
 			"appendArgsToExecutable": true
 		}
 	}
+,
+	"Sony PlayStation - DuckStation": {
+		"parserType": "Glob",
+		"configTitle": "Sony PlayStation - DuckStation",
+		"steamCategory": "${PS1}",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "-batch -fullscreen \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"SteamGridDB"
+		],
+		"defaultImage": "",
+		"defaultTallImage": "",
+		"defaultHeroImage": "",
+		"defaultLogoImage": "",
+		"localImages": "",
+		"localTallImages": "",
+		"localHeroImages": "",
+		"localLogoImages": "",
+		"localIcons": "",
+		"disabled": false,
+		"advanced": false,
+		"userAccounts": {
+			"specifiedAccounts": "",
+			"skipWithMissingDataDir": true,
+			"useCredentials": true
+		},
+		"parserInputs": {
+			"glob": "${title}@(.bin|.BIN|.chd|.CHD|.cue|.CUE|.ecm|.ECM|.exe|.EXE|.img|.IMG|.iso|.ISO|.m3u|.M3U|.mds|.MDS|.pbp|.PBP|.psexe|.PSEXE|.psf|.PSF)",
+			"glob-regex": null
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false,
+			"tryToMatchTitle": false
+		},
+		"fuzzyMatch": {
+			"use": true,
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "${path-to-duckstation-nogui-x64-ReleaseLTCG.exe}",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		}
+	}
+,
+	"Sony PlayStation - Retroarch - DuckStation": {
+		"parserType": "Glob",
+		"configTitle": "Sony PlayStation - Retroarch - DuckStation",
+		"steamCategory": "${PS1}",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "-L ${os:win|cores|${os:mac|cores|${os:linux|${racores}}}}${/}duckstation_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"SteamGridDB"
+		],
+		"defaultImage": "",
+		"defaultTallImage": "",
+		"defaultHeroImage": "",
+		"defaultLogoImage": "",
+		"localImages": "",
+		"localTallImages": "",
+		"localHeroImages": "",
+		"localLogoImages": "",
+		"localIcons": "",
+		"disabled": false,
+		"advanced": false,
+		"userAccounts": {
+			"specifiedAccounts": "",
+			"skipWithMissingDataDir": true,
+			"useCredentials": true
+		},
+		"parserInputs": {
+			"glob": "${title}@(.bin|.BIN|.chd|.CHD|.cue|.CUE|.ecm|.ECM|.exe|.EXE|.img|.IMG|.iso|.ISO|.m3u|.M3U|.mds|.MDS|.pbp|.PBP|.psexe|.PSEXE|.psf|.PSF)",
+			"glob-regex": null
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false,
+			"tryToMatchTitle": false
+		},
+		"fuzzyMatch": {
+			"use": true,
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "${retroarchpath}",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		}
+	}
 }


### PR DESCRIPTION
Adds presets for use with the standalone and RetroArch versions of [DuckStation](https://github.com/stenzek/duckstation).