### PR TITLE
also check under /var/run/host for executables when running inside flatpak

### DIFF
--- a/src/renderer/services/parsers.service.ts
+++ b/src/renderer/services/parsers.service.ts
@@ -311,6 +311,17 @@ export class ParsersService {
       else
         return true;
     } catch (e) {
+	  if (process.env["IN_FLATPAK"]) {
+		try {
+			let path = fs.statSync("/var/run/host" + fsPath);
+			if (checkForDirectory !== undefined)
+			  return checkForDirectory ? path.isDirectory() : path.isFile();
+			else
+			  return true;
+		} catch (e) {
+			return false;
+		}
+	  }
       return false;
     }
   }


### PR DESCRIPTION
when validating path for executables also check the path with `/var/run/host` prepending it so that host binaries can be specified in the executable path field in the parsers 