### PR TITLE
Multiplatform itchio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In addition to flexible importing of ROMS, SRM now has several *platform parsers
 |[Amazon Games](https://gaming.amazon.com/amazon-games-app)|✅|❌|❌|
 |[Epic](https://store.epicgames.com/en-US/) / [Legendary](https://github.com/derrod/legendary)|✅|✅|❌|
 |[GOG Galaxy](https://www.gog.com/galaxy)|✅|❌|❌|
-|[Itch.io](https://itch.io/app)|✅|❌|❌|
+|[Itch.io](https://itch.io/app)|✅|✅|✅|
 |[UPlay](https://ubisoftconnect.com/en-US/)|✅|❌|❌|
 
 Planned platform parsers include Origin, the EA Games Store, and Battle.net.

--- a/src/lang/english/langData.ts
+++ b/src/lang/english/langData.ts
@@ -194,7 +194,7 @@ export const EnglishLang: languageContainer = {
       },
       errors: {
         invalidItchIoAppDataOverride: "> itch.io AppData Override is not a valid directory.",
-        osUnsupported: "> itch.io parser failed because the parser only supports windows currently.",
+        osUnsupported: "> itch.io parser failed because the parser only supports macos, linux, and windows currently.",
         fatalError__i: '> itch.io parser failed with fatal error:\n ${error}'
       }
     },

--- a/src/lang/english/markdown/itch-io-parser-input.md
+++ b/src/lang/english/markdown/itch-io-parser-input.md
@@ -1,4 +1,5 @@
 # Unique inputs for itch.io Parser
 
 ## itch.io AppData Path Override
-By default Steam ROM Manager assumes your itch.io app data is located at `%APPDATA%\itch`. This field allows you to override that path if your itch.io app data is elsewhere.
+By default Steam ROM Manager assumes your itch.io app data is located at `%APPDATA%\itch` on windows `$HOME/.config/itch` on linux and `$HOME/Library/Application Support/itch` on macos.
+This field allows you to override that path if your itch.io user data is elsewhere.

--- a/src/lib/parsers/itch-io.parser.ts
+++ b/src/lib/parsers/itch-io.parser.ts
@@ -15,7 +15,7 @@ export class ItchIoParser implements GenericParser {
       title: 'itch.io',
       info: this.lang.docs__md.self.join(''),
       inputs: {
-        'itchIoAppDataDir': {
+        'itchIoAppDataOverride': {
           label: this.lang.itchIoAppDataOverrideTitle,
           inputType: 'dir',
           validationFn: (input: string) => {
@@ -45,7 +45,7 @@ export class ItchIoParser implements GenericParser {
             case "Linux":
               return `${process.env.HOME}/.config/itch`;
             case "Darwin":
-              return `${process.env.HOME}/Library/Application Support/itch"`;
+              return `${process.env.HOME}/Library/Application Support/itch`;
           }
         })();
         const dbPath = os.type()=="Windows_NT" ? `${itchIoAppDataDir}\\db\\butler.db`:`${itchIoAppDataDir}/db/butler.db`;

--- a/src/lib/parsers/itch-io.parser.ts
+++ b/src/lib/parsers/itch-io.parser.ts
@@ -15,11 +15,11 @@ export class ItchIoParser implements GenericParser {
       title: 'itch.io',
       info: this.lang.docs__md.self.join(''),
       inputs: {
-        'itchIoAppDataOverride': {
+        'itchIoAppDataDir': {
           label: this.lang.itchIoAppDataOverrideTitle,
           inputType: 'dir',
           validationFn: (input: string) => {
-            if(!input || fs.existsSync(input) && fs.lstatSync(input).isFile()) {
+            if(!input || fs.existsSync(input) && !fs.lstatSync(input).isFile()) {
               return null;
             } else {
               return this.lang.errors.invalidItchIoAppDataOverride;
@@ -34,16 +34,21 @@ export class ItchIoParser implements GenericParser {
   execute(directories: string[], inputs: { [key: string]: any }, cache?: { [key: string]: any }) {
     return new Promise<ParsedData>((resolve,reject)=>{
       try {
-        if(os.type()!='Windows_NT') {
+        if(!["Windows_NT", "Linux", "Darwin"].includes(os.type())) {
           reject(this.lang.errors.osUnsupported);
         }
 
-        const itchIoAppDataDir = inputs.itchIoAppDataOverride || `${process.env.APPDATA}\\itch`;
-        const dbPath = `${itchIoAppDataDir}\\db\\butler.db`;
-
-        if(!fs.existsSync(dbPath)) {
-          reject();
-        }
+        const itchIoAppDataDir = inputs.itchIoAppDataOverride || (() => {
+          switch(os.type()) {
+            case "Windows_NT":
+              return `${process.env.APPDATA}\\itch`;
+            case "Linux":
+              return `${process.env.HOME}/.config/itch`;
+            case "Darwin":
+              return `${process.env.HOME}/Library/Application Support/itch"`;
+          }
+        })();
+        const dbPath = os.type()=="Windows_NT" ? `${itchIoAppDataDir}\\db\\butler.db`:`${itchIoAppDataDir}/db/butler.db`;
 
         const db = sqlite(dbPath);
         const games: { extractedTitle:string, filePath:string }[] = db.prepare(
@@ -56,16 +61,21 @@ export class ItchIoParser implements GenericParser {
             return null;
           }
 
-          const exePath = candidates[0].path.replace('/','\\');
+            const exePath = candidates[0].path;
+            let filePath = `${basePath}/${exePath}`
 
-          return { 
-            extractedTitle: title,
-            filePath: `${basePath}\\${exePath}`,
-          };
-        })
-        .filter((gameDetails:any) => gameDetails !== null);
 
-        resolve({success: games, failed:[]});
+            if(os.type() == "Windows_NT") {
+              filePath = filePath.replace('/','\\');
+            }
+
+            return { 
+              extractedTitle: title,
+              filePath: filePath,
+            };
+          })
+          .filter((gameDetails:any) => gameDetails !== null);
+          resolve({success: games, failed:[]});
       } catch(err) {
         Sentry.captureException(err);
         reject(this.lang.errors.fatalError__i.interpolate({error: err}));


### PR DESCRIPTION
Hello!

I got the itchio parser working on linux and macos. The app's database is identical across the three platforms so this change just adds other default paths for linux and mac database locations. 

I don't program a lot of typescript so let me know if there are any style errors or non-idiomatic things I should fix. 