### PR TITLE
Write icon before tags in steam shortcuts

### DIFF
--- a/src/lib/vdf-manager.ts
+++ b/src/lib/vdf-manager.ts
@@ -167,8 +167,8 @@ export class VDF_Manager {
                 item.exe = app.executableLocation;
                 item.StartDir = app.startInDirectory;
                 item.LaunchOptions = app.argumentString;
-                item.tags = _.union(app.steamCategories, item.tags);
                 item.icon = icon_path;
+                item.tags = _.union(app.steamCategories, item.tags);
               }
               else if(app.parserType !== 'Steam') {
                 listItem.shortcuts.addItem(appId, {
@@ -177,8 +177,8 @@ export class VDF_Manager {
                   exe: app.executableLocation,
                   StartDir: app.startInDirectory,
                   LaunchOptions: app.argumentString,
-                  tags: app.steamCategories,
-                  icon: icon_path
+                  icon: icon_path,
+                  tags: app.steamCategories
                 });
               }
 


### PR DESCRIPTION
This PR makes sure that tags are the last thing written in each shortcut in the shortcuts.vdf file.

While it is valid vdf not to do so, and steam will accept it, Steam itself always puts the tags at the end of shortcuts.
This ensures that 3rd party tools can read the shortcut file.
It also ensures that the shortcuts are understandable by steam, even if they make their own shortcut parser stricter in the future.