### PR TITLE
Handle cases where `Exec` is an array or contains arguments

### DIFF
--- a/src/lib/file-parser.ts
+++ b/src/lib/file-parser.ts
@@ -396,9 +396,11 @@ export class FileParser {
                   return filehandle.readFile("utf8");
                 }).then(data => {
                   let entry = xdgparse.parse(data)["Desktop Entry"];
-                  let modifiedExecutableLocation=entry["Exec"];
+                  let splitExec = String(entry["Exec"]).match(/(?:(?:\S*\\\s)+|(?:[^\s"]+|"[^"]*"))+/g);
+                  let modifiedExecutableLocation = splitExec.shift();
                   parsedConfig.files[j].modifiedExecutableLocation = modifiedExecutableLocation;
-                  parsedConfig.files[j].startInDirectory = entry["Path"] || path.dirname(modifiedExecutableLocation);
+                  parsedConfig.files[j].startInDirectory = (entry["Path"] && String(entry["Path"])) || path.dirname(modifiedExecutableLocation);
+                  parsedConfig.files[j].argumentString = splitExec.join(' ');
                 })
               shortcutPromises.push(shortcutPromise);
             }


### PR DESCRIPTION
In some cases, the `Exec` field of the DESKTOP file will contain arguments (that then filtered their way into the starting directory) or with be presented as an array by xdg-parse (crashing the parser). This handles those cases.