### PR TITLE
Allow bin files for Genesis Plus GX

### DIFF
--- a/files/presets/Sega Genesis+Mega Drive.json
+++ b/files/presets/Sega Genesis+Mega Drive.json
@@ -32,7 +32,7 @@
 			"useCredentials": true
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.bin|.BIN)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -99,7 +99,7 @@
 			"useCredentials": true
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.bin|.BIN)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",


### PR DESCRIPTION
According to the [RetroPie Docs](https://retropie.org.uk/docs/Mega-Drive-Genesis/) and my experience, `.bin` files should be accepted by default when using the Genesis Plus GX core.

I am not sure if there is another location in the code base that would need to be updated for this change.