### PR TITLE
Preset for both CMD and GUI Yuzu

### DIFF
--- a/files/presets/Nintendo Switch.json
+++ b/files/presets/Nintendo Switch.json
@@ -133,7 +133,7 @@
 			}
 		}
 	},
-	"Nintendo Switch - Yuzu": {
+	"Nintendo Switch - Yuzu CMD": {
 		"parserType": "Glob",
 		"configTitle": "Nintendo Switch - Yuzu",
 		"steamCategory": "${}",
@@ -182,6 +182,73 @@
 		},
 		"executable": {
 			"path": "path-to-yuzu-cmd.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 3,
+		"imageProviderAPIs": {
+			"SteamGridDB": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			}
+		}
+	},
+    "Nintendo Switch - Yuzu GUI": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Switch - Yuzu",
+		"steamCategory": "${}",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "-f -g \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"SteamGridDB"
+		],
+		"defaultImage": "",
+		"defaultTallImage": "",
+		"defaultHeroImage": "",
+		"defaultLogoImage": "",
+		"defaultIcon": "",
+		"localImages": "",
+		"localTallImages": "",
+		"localHeroImages": "",
+		"localLogoImages": "",
+		"localIcons": "",
+		"disabled": false,
+		"advanced": false,
+		"userAccounts": {
+			"specifiedAccounts": "",
+			"skipWithMissingDataDir": true,
+			"useCredentials": true
+		},
+		"parserInputs": {
+			"glob": "${title}@(.kip|.KIP|.nca|.NCA|.nro|.NRO|.nso|.NSO|.nsp|.NSP|.xci|.XCI)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false,
+			"tryToMatchTitle": false
+		},
+		"fuzzyMatch": {
+			"use": true,
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-yuzu.exe",
 			"shortcutPassthrough": false,
 			"appendArgsToExecutable": true
 		},


### PR DESCRIPTION
Current Yuzu preset runs the cmd version, I like to have the gui to change settings. This edit adds the two options for Windows.

The GUI version also has the -g flag added back, because it needs it to boot directly into the rom.