### PR TITLE
Fix some broken tables in the documentation

### DIFF
--- a/src/lang/english/markdown/executable-arguments.md
+++ b/src/lang/english/markdown/executable-arguments.md
@@ -177,12 +177,12 @@ In case fuzzy matching **fails** or is **disabled**, `${fuzzyTitle}`{.noWrap} is
 
 |Variable (case-insensitive)|Corresponding function|
 |---:|:---|
-|`${regex|input|substitution(optional)}`|Executes regex on input. Supports `u`, `g` and `i` flags (captured groups are joined, unless substitution is provided)|
-|`${uc|input}`|Uppercase variable. Transforms input to uppercase|
-|`${lc|input}`|Lowercase variable. Transforms input to lowercase|
-|`${cv:group|input}`|Change input with matched custom variable (group is optional)|
-|`${rdc|input}`|Replace diacritic input characters with their latin equivalent|
-|`${os:[win|mac|linux]|on match|no match(optional)}`|If OS matches, uses `on match` value or `no match` otherwise|
+|`${regex\|input\|substitution(optional)}`|Executes regex on input. Supports `u`, `g` and `i` flags (captured groups are joined, unless substitution is provided)|
+|`${uc\|input}`|Uppercase variable. Transforms input to uppercase|
+|`${lc\|input}`|Lowercase variable. Transforms input to lowercase|
+|`${cv:group\|input}`|Change input with matched custom variable (group is optional)|
+|`${rdc\|input}`|Replace diacritic input characters with their latin equivalent|
+|`${os:[win\|mac\|linux]\|on match\|no match(optional)}`|If OS matches, uses `on match` value or `no match` otherwise|
 
 ### Function variable example
 

--- a/src/lang/english/markdown/executable-modifier.md
+++ b/src/lang/english/markdown/executable-modifier.md
@@ -65,12 +65,12 @@ In case fuzzy matching **fails** or is **disabled**, `${fuzzyTitle}`{.noWrap} is
 
 |Variable (case-insensitive)|Corresponding function|
 |---:|:---|
-|`${regex|input|substitution(optional)}`|Executes regex on input. Supports `u`, `g` and `i` flags (captured groups are joined, unless substitution is provided)|
-|`${uc|input}`|Uppercase variable. Transforms input to uppercase|
-|`${lc|input}`|Lowercase variable. Transforms input to lowercase|
-|`${cv:group|input}`|Change input with matched custom variable (group is optional)|
-|`${rdc|input}`|Replace diacritic input characters with their latin equivalent|
-|`${os:[win|mac|linux]|on match|no match(optional)}`|If OS matches, uses `on match` value or `no match` otherwise|
+|`${regex\|input\|substitution(optional)}`|Executes regex on input. Supports `u`, `g` and `i` flags (captured groups are joined, unless substitution is provided)|
+|`${uc\|input}`|Uppercase variable. Transforms input to uppercase|
+|`${lc\|input}`|Lowercase variable. Transforms input to lowercase|
+|`${cv:group\|input}`|Change input with matched custom variable (group is optional)|
+|`${rdc\|input}`|Replace diacritic input characters with their latin equivalent|
+|`${os:[win\|mac\|linux]\|on match\|no match(optional)}`|If OS matches, uses `on match` value or `no match` otherwise|
 
 ### Function variable example
 

--- a/src/lang/english/markdown/parser-variables.md
+++ b/src/lang/english/markdown/parser-variables.md
@@ -55,12 +55,12 @@ In case fuzzy matching **fails** or is **disabled**, `${fuzzyTitle}`{.noWrap} is
 
 |Variable (case-insensitive)|Corresponding function|
 |---:|:---|
-|`${regex|input|substitution(optional)}`|Executes regex on input. Supports `u`, `g` and `i` flags (captured groups are joined, unless substitution is provided)|
-|`${uc|input}`|Uppercase variable. Transforms input to uppercase|
-|`${lc|input}`|Lowercase variable. Transforms input to lowercase|
-|`${cv:group|input}`|Change input with matched custom variable (group is optional)|
-|`${rdc|input}`|Replace diacritic input characters with their latin equivalent|
-|`${os:[win|mac|linux]|on match|no match(optional)}`|If OS matches, uses `on match` value or `no match` otherwise|
+|`${regex\|input\|substitution(optional)}`|Executes regex on input. Supports `u`, `g` and `i` flags (captured groups are joined, unless substitution is provided)|
+|`${uc\|input}`|Uppercase variable. Transforms input to uppercase|
+|`${lc\|input}`|Lowercase variable. Transforms input to lowercase|
+|`${cv:group\|input}`|Change input with matched custom variable (group is optional)|
+|`${rdc\|input}`|Replace diacritic input characters with their latin equivalent|
+|`${os:[win\|mac\|linux]\|on match\|no match(optional)}`|If OS matches, uses `on match` value or `no match` otherwise|
 
 ### Function variable example
 

--- a/src/lang/english/markdown/spec-glob-chars.md
+++ b/src/lang/english/markdown/spec-glob-chars.md
@@ -37,8 +37,8 @@ here are few examples of extended glob matchers in action:
 
 |Glob patterns|Matches (list numbers)|
 |:---|---:|
-|`@(dir[12]|DIR)/**/*.txt`|`1`, `2`, `4`, `5`|
-|`!(dir[12]|DIR)/**/*.txt`|`3`, `6`|
+|`@(dir[12]\|DIR)/**/*.txt`|`1`, `2`, `4`, `5`|
+|`!(dir[12]\|DIR)/**/*.txt`|`3`, `6`|
 |`*/!(*bb*)/*.txt`|`2`, `3`, `4`, `5`|
 |`*/?(abc)/*.txt`|`4`|
 |`*/+(abc)/*.txt`|`4`, `5`|


### PR DESCRIPTION
- Some pipes (`|`) weren't properly escaped