### PR TITLE
fixes yuzu preset

### DIFF
--- a/files/presets/Nintendo Switch.json
+++ b/files/presets/Nintendo Switch.json
@@ -142,7 +142,7 @@
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-f \"${filePath}\"",
+		"executableArgs": "-f -g \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -209,7 +209,7 @@
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.yuzu_emu.yuzu -f \"${filePath}\"",
+		"executableArgs": "run org.yuzu_emu.yuzu -f -g \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [


### PR DESCRIPTION
as mentioned in this [comment](https://github.com/SteamGridDB/steam-rom-manager/issues/98#issuecomment-1239618526) the old way no longer works, the args are listed before

link to the yuzu issue: https://github.com/yuzu-emu/yuzu/issues/5331

```yuzu.exe "path_to_game" - Launches a game at path_to_game
yuzu.exe -f - Launches the next game in fullscreen
yuzu.exe -g "path_to_game" - Launches a game at path_to_game
yuzu.exe -f -g "path_to_game" - Launches a game at path_to_game in fullscreen```