### PR TITLE
Slight tweaks to presets for Gamecube and Wii 

### DIFF
--- a/files/presets/Nintendo GameCube.json
+++ b/files/presets/Nintendo GameCube.json
@@ -8,7 +8,7 @@
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-b -e \"${filePath}\"",
+		"executableArgs": "--batch --exec \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [

--- a/files/presets/Nintendo Wii.json
+++ b/files/presets/Nintendo Wii.json
@@ -8,7 +8,7 @@
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-b -e \"${filePath}\"",
+		"executableArgs": "--batch --exec \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [


### PR DESCRIPTION
To keep this brief: whenever I tried to launch dolphin through steam with this, it failed to launch. Much searching brought me to issue [409](https://github.com/SteamGridDB/steam-rom-manager/issues/409). After seeing it, I did some experimentation and found that, while -b -e failed to launch, changing it to --batch --exec let dolphin launch with no issue. I cannot tell you why this is, I looked at dolphin's source code and didn't see anything that looked like an obvious cause.

I didn't tweak any presets other than "Nintendo GameCube - Dolphin" and "Nintendo Wii - Dolphin" as I only tested with a standard dolphin install sans retroarch, and didn't want to add any tweaks I hadn't tested. However, those may also be worth investigating.