### PR TITLE
Revert "Using `com.epicgames.launcher://` as `executableLocation` inside Epic parser"

### DIFF
--- a/src/lib/parsers/epic.parser.ts
+++ b/src/lib/parsers/epic.parser.ts
@@ -71,15 +71,15 @@ export class EpicParser implements GenericParser {
       })
       .then(()=>{
         let parsedData: ParsedData = {
+          executableLocation: `C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
           success: [],
           failed:[]
         };
         for(let i=0; i < appTitles.length; i++){
           parsedData.success.push({
-            executableLocation: `com.epicgames.launcher://apps/${appNames[i]}?action=launch&silent=true`,
             extractedTitle: appTitles[i],
             extractedAppId: appNames[i] ,
-            launchOptions: ``,
+            launchOptions: `-windowStyle hidden -NoProfile -ExecutionPolicy Bypass -Command "&Start-Process \\"com.epicgames.launcher://apps/${appNames[i]}?action=launch&silent=true\\""`,
             filePath: appPaths[i]
           });
         }


### PR DESCRIPTION
Reverts SteamGridDB/steam-rom-manager#403

Original PR was broken