### PR TITLE
Fixing Issues UWP when the app has special characters in the json

### DIFF
--- a/src/lib/parsers/UWP.parser.ts
+++ b/src/lib/parsers/UWP.parser.ts
@@ -324,8 +324,13 @@ function getIndirectResourceString(fullName: string, packageName: string, resour
 function getUWPAppDetail(manifest: SimpleManifest, xmlParser: XMLParser) {
   var uwpApp: SimpleUWPApp = {} as SimpleUWPApp;
 
+  const command = `$PkgMgr = [Windows.Management.Deployment.PackageManager,Windows.Web,ContentType=WindowsRuntime]::new(); 
+            $package = $PkgMgr.FindPackagesForUser([System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value, "${manifest.idName}", "${manifest.idPublisher}"); 
+            $newObject = $package | Select-Object IsFramework, IsResourcePackage, SignatureKind, IsBundle, InstalledLocation, InstalledPath, Id; 
+            $newObject | ConvertTo-Json`
+
   const searchResults = spawnSync(
-    `$PkgMgr = [Windows.Management.Deployment.PackageManager,Windows.Web,ContentType=WindowsRuntime]::new(); $PkgMgr.FindPackagesForUser([System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value, "${manifest.idName}", "${manifest.idPublisher}") | ConvertTo-Json`,
+    command,
       {
       shell: 'powershell',
       encoding: "utf-8",


### PR DESCRIPTION
The Json that was generated by PowerShell was not escaping specialized characters properly. This check-in reduces the number of fields brought back from the PowerShell command to be localized to the fields used. This fixes issue #500. 