### PR TITLE
Filter controller template candidates to only include files

### DIFF
--- a/src/lib/controller-manager.ts
+++ b/src/lib/controller-manager.ts
@@ -59,7 +59,8 @@ export class ControllerManager {
   static readTemplates(steamDirectory: string, controllerType: string) {
     let templateDirUser = path.join(steamDirectory, 'steamapps', 'workshop', 'content', '241100')
     let filesUser = glob.sync('*/*', { dot: true, cwd: templateDirUser, absolute: true });
-    let parsedTemplatesUser: ControllerTemplate[] = filesUser.map((f: string) => Object.assign({ mappingId: f.split(path.sep).slice(-2)[0] }, genericParser.parse(fs.readFileSync(f, 'utf-8'))))
+    let parsedTemplatesUser: ControllerTemplate[] = filesUser.filter((f: string) => fs.lstatSync(f).isFile())
+      .map((f: string) => Object.assign({ mappingId: f.split(path.sep).slice(-2)[0] }, genericParser.parse(fs.readFileSync(f, 'utf-8'))))
       .filter((x: any) => !!x['controller_mappings']
         && !!x['controller_mappings']['title']
         && !!x['controller_mappings']['controller_type']


### PR DESCRIPTION
Fixes error `Error: EISDIR: illegal operation on a directory, read` which occurs when attempting to re-fetch controller templates in the case where steam has created a directory alongside one of the controller configuration files. This PR filters controller template candidates to ensure they are actually files before attempting to read them.

Example scenario (what things currently look like on my Windows desktop and my steam deck):
```
steam
|-->steamapps
    |-->workshop
        |-->...
        |-->577059625
            |-->controller_configuration.vdf
            |-->workshop // without filtering, SRM attempts to read this as a file and controller templates fail to fetch
                |-->440
                    |-->...
                |-->650
                    |-->...
                |-->...
```