### PR TITLE
[Legendary] Fix use legendaryInstalledFile if user inputs value

### DIFF
--- a/src/lib/parsers/legendary.parser.ts
+++ b/src/lib/parsers/legendary.parser.ts
@@ -32,7 +32,7 @@ export class LegendaryParser implements GenericParser {
       let appPaths: string[] = [];
       let legendaryInstalledFile: string = "";
       if(inputs.legendaryInstalledFile) {
-        legendaryInstalledFile = inputs.epicManifests;
+        legendaryInstalledFile = inputs.legendaryInstalledFile;
       } else {
         legendaryInstalledFile = path.join(os.homedir(),'.config/legendary/installed.json');
       }


### PR DESCRIPTION
I'm new with this repo so I might be wrong.

I think when making the legendary parser, most of its logic was copied over from the epic parser.
From that assumption I think this if branch was copied over but the variable assignment from the body was not changed.

This causes that when the user inputs a custom location for installed.json then the parser fails.
Epic parser:
https://github.com/SteamGridDB/steam-rom-manager/blob/b002718aebc476ef555c4eece319a31b72b26559/src/lib/parsers/epic.parser.ts#L45-L46
Legendary parser:
https://github.com/SteamGridDB/steam-rom-manager/blob/b002718aebc476ef555c4eece319a31b72b26559/src/lib/parsers/legendary.parser.ts#L34-L35
