### PR TITLE
rpcs3 Profile update - Separate PS3 and PSN custom variable

### DIFF
--- a/files/customVariables.json
+++ b/files/customVariables.json
@@ -46334,6 +46334,8 @@
         "KTGS30320": "Sophie no Atelier: Fushigi na Hon no Renkinjutsushi (Premium Box)",
         "MRTC00002": "Lost Planet 2",
         "MRTC00014": "Mindjack",
+	},
+	"PSN": {
         "NPEA00006": "Go! Puzzle",
         "NPEA00015": "Nucleus",
         "NPEA00041": "Tori-Emaki",

--- a/files/customVariables.json
+++ b/files/customVariables.json
@@ -49674,6 +49674,7 @@
         "MDFN90002": "Mednafen Emulator",
         "NEOTRAIL1": "Neo Trail",
         "NORSX0000": "NORSX: A 2D Library for PSL1GHT",
+        "NP0APOLLO": "Apollo Save Tool (PS3)",
         "PCEE00000": "PCE Emu",
         "PKGMANAGE": "XMB Manager Plus",
         "PKGMANAGR": "XMB Manager Plus",

--- a/files/presets/Sony PlayStation 3.json
+++ b/files/presets/Sony PlayStation 3.json
@@ -1,7 +1,7 @@
 {
-	"Sony PlayStation 3 - RPCS3 (Extracted ISO/PSN)": {
+	"Sony PlayStation 3 - RPCS3 (Extracted ISO)": {
 		"parserType": "Glob",
-		"configTitle": "Sony PlayStation 3 - RPCS3 (Extracted ISO/PSN)",
+		"configTitle": "Sony PlayStation 3 - RPCS3 (Extracted ISO)",
 		"steamCategory": "${PS3}",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
@@ -78,9 +78,9 @@
 			"icon": ""
 		}
 	},
-	"Sony PlayStation 3 - RPCS3(Flatpak) (Extracted ISO/PSN)": {
+	"Sony PlayStation 3 - RPCS3(Flatpak) (Extracted ISO)": {
 		"parserType": "Glob",
-		"configTitle": "Sony PlayStation 3 - RPCS3(Flatpak) (Extracted ISO/PSN)",
+		"configTitle": "Sony PlayStation 3 - RPCS3(Flatpak) (Extracted ISO)",
 		"steamCategory": "${PS3}",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
@@ -181,7 +181,7 @@
 			"glob": "${title}/USRDIR/@(eboot.bin|EBOOT.BIN)"
 		},
 		"titleFromVariable": {
-			"limitToGroups": "${PS3}",
+			"limitToGroups": "${PSN}",
 			"caseInsensitiveVariables": false,
 			"skipFileIfVariableWasNotFound": false,
 			"tryToMatchTitle": true
@@ -260,7 +260,7 @@
 			"glob": "${title}/USRDIR/@(eboot.bin|EBOOT.BIN)"
 		},
 		"titleFromVariable": {
-			"limitToGroups": "${PS3}",
+			"limitToGroups": "${PSN}",
 			"caseInsensitiveVariables": false,
 			"skipFileIfVariableWasNotFound": false,
 			"tryToMatchTitle": true


### PR DESCRIPTION
-Separate PS3 and PSN in the custom variable
-Rename the profiles accordingly

SRM creates shortcuts for games and their updates which is bothersome, separating it should solve it as Extracted ISOs should be in "rpcs3\games" and PSN games in "rpcs3\dev_hdd0\game"

Closes https://github.com/SteamGridDB/steam-rom-manager/issues/606 & https://github.com/SteamGridDB/steam-rom-manager/issues/561