### PR TITLE
Adds Cemu Profile - NUS/WUP Format

### DIFF
--- a/files/presets/Nintendo Wii U.json
+++ b/files/presets/Nintendo Wii U.json
@@ -235,5 +235,85 @@
 			"logo": "",
 			"icon": ""
 		}
+	},
+	"Nintendo Wii U - Cemu (NUS/WUP)": {
+        "parserType": "Glob",
+        "configTitle": "Nintendo WiiU - Cemu (NUS/WUP)",
+        "steamDirectory": "${steamdirglobal}",
+        "steamCategory": "${Wii U}",
+        "romDirectory": "path-to-roms",
+        "executableArgs": "-f -g \"${filePath}\"",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "imageProviders": [],
+        "onlineImageQueries": "${${fuzzyTitle}}",
+        "imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"SteamGridDB"
+		],
+		"disabled": false,
+		"advanced": false,
+		"userAccounts": {
+			"specifiedAccounts": ""
+		},
+		"parserInputs": {
+			"glob": "${title}/@(title.tmd|.TMD)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false,
+			"tryToMatchTitle": false
+		},
+		"fuzzyMatch": {
+			"use": true,
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-cemu.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 7,
+		"imageProviderAPIs": {
+			"SteamGridDB": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": "${dir}/../*${/\\[.*?\\]/g|${title}|}*/meta/iconTex.tga"
+		}
 	}
 }


### PR DESCRIPTION
Support for games in NUS/WUP format added in September (collection of .app files + title.tmd + title.tik)

See https://github.com/cemu-project/Cemu/pull/981

Cemu scans everything from the folder + subfolders thus handling update/dlc automatically.

We only need to launch the title.tmd from the main game. Update/DLC folder should be elsewhere for easier managment but added to the Cemu internal settings.