### PR TITLE
[Fix] Change to file-parser.ts to fix appending of arguments.

### DIFF
--- a/src/lib/file-parser.ts
+++ b/src/lib/file-parser.ts
@@ -412,7 +412,7 @@ export class FileParser {
     return new Promise((resolve, reject)=>{
       try{
         for(let j=0; j < parsedConfig.files.length; j++) {
-          if(config.executable.appendArgsToExecutable) {
+          if(parsedConfig.appendArgsToExecutable) {
             parsedConfig.files[j].modifiedExecutableLocation = `${parsedConfig.files[j].modifiedExecutableLocation} ${parsedConfig.files[j].argumentString}`;
             parsedConfig.files[j].argumentString = '';
           }


### PR DESCRIPTION
This should fix #625

It seems like it should be referencing the parsed config instead of the regular config.
There is some extra processing of `appendArgstoExecutable` in `buildParsedConfigsPromise` that otherwise doesn't seem to be used and seems intended to be used for this.