### PR TITLE
Update en-us/markdown/user-accounts.md

### DIFF
--- a/src/lang/en-US/markdown/user-accounts.md
+++ b/src/lang/en-US/markdown/user-accounts.md
@@ -16,4 +16,4 @@ You can also set this field using the `Accounts Global` environment variable fou
 
 ## Warning
 
-If you have `Don't save account credentials on this computer` set in Steam, then there is no way for SRM to know your `Steam Username` and **you must only use** `Account IDs`. If you would like to use `Steam Usernames` here, go to `Steam > Settings > Account` and disable `Don't save account credentials on this computer`, then restart both Steam and SRM.
+If you have `Don't save account credentials on this computer` set in Steam, then there is no way for SRM to know your `Steam Username` and **you must only use** `Account IDs`. If you would like to use `Steam Usernames` here, go to `Steam > Settings > Settings` and disable `Don't save account credentials on this computer`, then restart both Steam and SRM.


### PR DESCRIPTION
The save account credentials option moved from Account to Security and this is not updated in the documentation.

This pr might not be perfect. I didn't update the other languages so that might need to be done. Not sure how the different languages for this project work.