### PR TITLE
Fix PR Pipeline and Update github actions versions

### DIFF
--- a/.github/workflows/discord_release_hook.yml
+++ b/.github/workflows/discord_release_hook.yml
@@ -9,12 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.6
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v4.0.2
         with:
-          node-version: 14.18.1
+          node-version: 22.2.0
           check-latest: true
 
       - name: Execute Discord webhook script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
 
       - name: Setup Python environment
         uses: actions/setup-python@v4
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.10'
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 22.2.0
           check-latest: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       - name: Upload Artifacts Windows
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ matrix.os == 'windows-latest' }}
         with:
           name: srm-build-windows
@@ -67,13 +67,13 @@ jobs:
             release/*.exe
             release/*.msi
       - name: Upload Artifacts Mac
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ matrix.os == 'macOS-latest' }}
         with:
           name: srm-build-mac
           path: release/*.dmg
       - name: Upload Artifacts Linux
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: srm-build-linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4.1.6
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -20,8 +20,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4.1.6
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
         with:
-          lfs: true
+          python-version: '3.10'
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4.0.2
@@ -32,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g npm@10.8.0
-          npm install
+          npm ci
 
       - name: Build
         run: |

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -56,7 +56,7 @@ jobs:
         run: npm run build:mac -- --publish=never
 
       - name: Upload Artifacts Windows
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ matrix.os == 'windows-latest' }}
         with:
           name: srm-build-windows
@@ -64,7 +64,7 @@ jobs:
             release/*.exe
             release/*.msi
       - name: Upload Artifacts Linux
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: srm-build-linux
@@ -72,7 +72,7 @@ jobs:
             release/*.deb
             release/*.AppImage
       - name: Upload Artifacts Mac
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ matrix.os == 'macOS-latest' }}
         with:
           name: srm-build-mac

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install -g npm@10.8.0
+          # npm install -g npm@10.8.0
           npm ci
 
       - name: Build

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4.1.6
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -71,3 +71,11 @@ jobs:
           path: |
             release/*.deb
             release/*.AppImage
+      - name: Upload Artifacts Mac
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.os == 'macOS-latest' }}
+        with:
+          name: srm-build-mac
+          path: |
+            release/*.dmg
+            release/*.zip

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 22.2.0
           check-latest: true

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4.1.6
+        with:
+          lfs: true
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4.0.2

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # npm install -g npm@10.8.0
-          npm ci
+          npm install -g npm@10.8.0
+          npm install
 
       - name: Build
         run: |


### PR DESCRIPTION
* Updated the following actions to fix the node js deprecation warnings
  * actions/checkout@v2 -> 4.1.6
  * actions/setup-node@v2.4.1 -> 4.0.2
    * node-version: 14.18.1 -> 22.2.0
  * actions/setup-python@v4 -> 5.1.0
  * actions/upload-artifact@v3 -> 4.3.3
* Fix the PR Pipeline: I noticed the pull request workflow failed the `Install dependencies` step when the `Setup Python environment` step wasn't run first. So I added the python step step before dependencies are installed.
* Not sure if it was intended, but the macOS build artifacts were not being uploaded in the pull requests workflow while the Windows and Linux versions were. I added a step to upload them.