### PR TITLE
Parsing of GOG games installed directly instead of via GOG Galaxy DB

### DIFF
--- a/src/lang/en-US/langStrings.json
+++ b/src/lang/en-US/langStrings.json
@@ -159,6 +159,7 @@
     "galaxyExeOverridePlaceholder": "/path/to/GalaxyClient.exe",
     "launcherModeInputTitle": "Launch games via GOG Galaxy",
     "parseLinkedExecsTitle": "Parse linked executables from GOG Galaxy",
+    "parseRegistryEntries": "Parse using registry entries instead of GOG Galaxy",
     "errors": {
       "invalidGalaxyExeOverride": "> Galaxy Client Override is not a valid path.",
       "fatalError__i": "> GOG Galaxy parser failed with fatal error:\n ${error}",

--- a/src/lang/en-US/langStrings.json
+++ b/src/lang/en-US/langStrings.json
@@ -159,7 +159,7 @@
     "galaxyExeOverridePlaceholder": "/path/to/GalaxyClient.exe",
     "launcherModeInputTitle": "Launch games via GOG Galaxy",
     "parseLinkedExecsTitle": "Parse linked executables from GOG Galaxy",
-    "parseRegistryEntries": "Parse using registry entries instead of GOG Galaxy",
+    "parseRegistryEntries": "Parse using Registry instead of Galaxy DB",
     "errors": {
       "invalidGalaxyExeOverride": "> Galaxy Client Override is not a valid path.",
       "fatalError__i": "> GOG Galaxy parser failed with fatal error:\n ${error}",

--- a/src/models/language.model.ts
+++ b/src/models/language.model.ts
@@ -245,6 +245,7 @@ export interface languageStruct {
     galaxyExeOverridePlaceholder: string,
     launcherModeInputTitle: string,
     parseLinkedExecsTitle: string,
+    parseRegistryEntries: string,
     docs__md: {
       self: string[],
       input: string[]


### PR DESCRIPTION
Change to the GOG Galaxy Parser to add option for finding games via the registry entries that are made on install instead of via the Galaxy DB.

Closes https://github.com/SteamGridDB/steam-rom-manager/issues/672

Notes:
I'm not entirely happy with how it handles DLC and the structure that has created. It probably looks bad to have failed matches even if it's just because they are DLC and thus shouldn't be matched, also it's made `getRegInstalled` somewhat redundant.

The alternative would be reverting to the original design and returning an empty success instead of a failed.

I'd welcome any clear critiques of my code, I'm learning Typescript on the fly with this.