### PR TITLE
Presets: Add ares systems

### DIFF
--- a/files/presets/Atari 2600.json
+++ b/files/presets/Atari 2600.json
@@ -1,4 +1,170 @@
 {
+	"Atari 2600 - ares": {
+		"parserType": "Glob",
+		"configTitle": "Atari 2600 - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Atari 2600\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.a26|.A26|.bin|.BIN|.rom|.ROM|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"2600"
+		]
+	},
+	"Atari 2600 - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Atari 2600 - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Atari 2600\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.a26|.A26|.bin|.BIN|.rom|.ROM|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"2600"
+		]
+	},
 	"Atari 2600 - Stella(Flatpak)": {
 		"parserType": "Glob",
 		"configTitle": "Atari 2600 - Stella(Flatpak)",

--- a/files/presets/Bandai Wanderswan Color.json
+++ b/files/presets/Bandai Wanderswan Color.json
@@ -1,0 +1,168 @@
+{
+	"Bandai WonderSwan Color - ares": {
+		"parserType": "Glob",
+		"configTitle": "Bandai WonderSwan Color - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"WonderSwan Color\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Wanderswan Color"
+		]
+	},
+	"Bandai WonderSwan Color - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Bandai WonderSwan Color - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"WonderSwan Color\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Wanderswan Color"
+		]
+	}
+}

--- a/files/presets/Bandai Wanderswan.json
+++ b/files/presets/Bandai Wanderswan.json
@@ -1,0 +1,168 @@
+{
+	"Bandai WonderSwan - ares": {
+		"parserType": "Glob",
+		"configTitle": "Bandai WonderSwan - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"WonderSwan\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Wanderswan"
+		]
+	},
+	"Bandai WonderSwan - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Bandai WonderSwan - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"WonderSwan\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Wanderswan"
+		]
+	}
+}

--- a/files/presets/Benesse Pocket Challenge V2.json
+++ b/files/presets/Benesse Pocket Challenge V2.json
@@ -1,0 +1,168 @@
+{
+	"Benesse Pocket Challenge V2 - ares": {
+		"parserType": "Glob",
+		"configTitle": "Benesse Pocket Challenge V2 - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Pocket Challenge V2\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Pocket Challenge V2"
+		]
+	},
+	"Benesse Pocket Challenge V2 - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Benesse Pocket Challenge V2 - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Pocket Challenge V2\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Pocket Challenge V2"
+		]
+	}
+}

--- a/files/presets/Coleco ColecoVision.json
+++ b/files/presets/Coleco ColecoVision.json
@@ -1,4 +1,170 @@
 {
+	"Coleco ColecoVision - ares": {
+		"parserType": "Glob",
+		"configTitle": "Coleco ColecoVision - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"ColecoVision\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.col|.COL|.ri|.RI|.rom|.ROM|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"ColecoVision"
+		]
+	},
+	"Coleco ColecoVision - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Coleco ColecoVision - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"ColecoVision\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.col|.COL|.ri|.RI|.rom|.ROM|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"ColecoVision"
+		]
+	},
 	"Coleco ColecoVision - Retroarch - BlueMSX": {
 		"parserType": "Glob",
 		"configTitle": "Coleco ColecoVision - Retroarch - BlueMSX",

--- a/files/presets/Microsoft MSX 2.json
+++ b/files/presets/Microsoft MSX 2.json
@@ -1,0 +1,168 @@
+{
+	"Microsoft MSX 2 - ares": {
+		"parserType": "Glob",
+		"configTitle": "Microsoft MSX 2 - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"MSX2\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"MSX2"
+		]
+	},
+	"Microsoft MSX 2 - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Microsoft MSX 2 - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"MSX2\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"MSX2"
+		]
+	}
+}

--- a/files/presets/Microsoft MSX.json
+++ b/files/presets/Microsoft MSX.json
@@ -1,4 +1,170 @@
 {
+	"Microsoft MSX - ares": {
+		"parserType": "Glob",
+		"configTitle": "Microsoft MSX - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"MSX\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"MSX"
+		]
+	},
+	"Microsoft MSX - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Microsoft MSX - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"MSX\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"MSX"
+		]
+	},
 	"Microsoft MSX - Retroarch - BlueMSX": {
 		"parserType": "Glob",
 		"configTitle": "Microsoft MSX - Retroarch - BlueMSX",

--- a/files/presets/NEC PC Engine CD+TurboGrafx CD.json
+++ b/files/presets/NEC PC Engine CD+TurboGrafx CD.json
@@ -1,4 +1,170 @@
 {
+	"NEC PC Engine CD/TurboGrafx CD - ares": {
+		"parserType": "Glob",
+		"configTitle": "NEC PC Engine CD/TurboGrafx CD - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"PC Engine CD\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"PCECD"
+		]
+	},
+	"NEC PC Engine CD/TurboGrafx CD - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "NEC PC Engine CD/TurboGrafx CD - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"PC Engine CD\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"PCECD"
+		]
+	},
 	"NEC PC Engine CD/TurboGrafx CD - Retroarch - Beetle PCE": {
 		"parserType": "Glob",
 		"configTitle": "NEC PC Engine/TurboGrafx 16 - Retroarch - Beetle PCE",

--- a/files/presets/NEC PC Engine SuperGrafx.json
+++ b/files/presets/NEC PC Engine SuperGrafx.json
@@ -1,4 +1,170 @@
 {
+	"NEC PC Engine SuperGrafx - ares": {
+		"parserType": "Glob",
+		"configTitle": "NEC PC Engine SuperGrafx - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"SuperGrafx\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"PCESGX"
+		]
+	},
+	"NEC PC Engine SuperGrafx - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "NEC PC Engine SuperGrafx - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"SuperGrafx\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"PCESGX"
+		]
+	},
 	"NEC PC Engine SuperGrafx - Retroarch - Beetle PCE": {
 		"parserType": "Glob",
 		"configTitle": "NEC PC Engine SuperGrafx - Retroarch - Beetle PCE",

--- a/files/presets/NEC PC Engine+TurboGrafx 16.json
+++ b/files/presets/NEC PC Engine+TurboGrafx 16.json
@@ -1,4 +1,170 @@
 {
+	"NEC PC Engine/TurboGrafx 16 - ares": {
+		"parserType": "Glob",
+		"configTitle": "NEC PC Engine/TurboGrafx 16 - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"PC Engine\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"PCE"
+		]
+	},
+	"NEC PC Engine/TurboGrafx 16 - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "NEC PC Engine/TurboGrafx 16 - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"PC Engine\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"PCE"
+		]
+	},
 	"NEC PC Engine/TurboGrafx 16 - Retroarch - Beetle PCE": {
 		"parserType": "Glob",
 		"configTitle": "NEC PC Engine/TurboGrafx 16 - Retroarch - Beetle PCE",

--- a/files/presets/Nintendo 64DD.json
+++ b/files/presets/Nintendo 64DD.json
@@ -1,0 +1,168 @@
+{
+	"Nintendo 64DD - ares": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo 64DD - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Nintendo 64DD\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"N64DD"
+		]
+	},
+	"Nintendo 64DD - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo 64DD - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Nintendo 64DD\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"N64DD"
+		]
+	}
+}

--- a/files/presets/Nintendo FDS.json
+++ b/files/presets/Nintendo FDS.json
@@ -1,0 +1,168 @@
+{
+	"Nintendo FDS - ares": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo FDS - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Famicom Disk System\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"FDS"
+		]
+	},
+	"Nintendo FDS - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo FDS - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Famicom Disk System\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"FDS"
+		]
+	}
+}

--- a/files/presets/Nintendo Game Boy Advance.json
+++ b/files/presets/Nintendo Game Boy Advance.json
@@ -1,7 +1,173 @@
 {
-	"Nintendo GameBoy - mGBA(Flatpak)": {
+	"Nintendo Game Boy Advance - ares": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - mGBA(Flatpak)",
+		"configTitle": "Nintendo Game Boy Advance - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Game Boy Advance\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Advance"
+		]
+	},
+	"Nintendo Game Boy Advance - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Advance - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy Advance\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Advance"
+		]
+	},
+	"Nintendo Game Boy Advance - mGBA(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Advance - mGBA(Flatpak)",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -20,7 +186,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -79,18 +245,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	},
-	"Nintendo GameBoy - Retroarch - Gambatte": {
+	"Nintendo Game Boy Advance - Retroarch - Beetle GBA": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch - Gambatte",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch - Beetle GBA",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gambatte_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_gba_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -103,7 +269,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.agb|.AGB|.bin|.BIN|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -162,18 +328,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	},
-	"Nintendo GameBoy - Retroarch(Flatpak) - Gambatte": {
+	"Nintendo Game Boy Advance - Retroarch(Flatpak) - Beetle GBA": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch(Flatpak) - Gambatte",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch(Flatpak) - Beetle GBA",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gambatte_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_gba_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -186,7 +352,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.agb|.AGB|.bin|.BIN|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -245,18 +411,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	},
-	"Nintendo GameBoy - Retroarch - Gearboy": {
+	"Nintendo Game Boy Advance - Retroarch - Meteor": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch - Gearboy",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch - Meteor",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gearboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}meteor_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -269,7 +435,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.sgb|.SGB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -328,18 +494,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	},
-	"Nintendo GameBoy - Retroarch(Flatpak) - Gearboy": {
+	"Nintendo Game Boy Advance - Retroarch(Flatpak) - Meteor": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch(Flatpak) - Gearboy",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch(Flatpak) - Meteor",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gearboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}meteor_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -352,7 +518,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.sgb|.SGB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -411,18 +577,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	},
-	"Nintendo GameBoy - Retroarch - Mesen-S": {
+	"Nintendo Game Boy Advance - Retroarch - VBA Next": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch - Mesen-S",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch - VBA Next",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mesen-s_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vba_next_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -435,7 +601,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -494,18 +660,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	},
-	"Nintendo GameBoy - Retroarch(Flatpak) - Mesen-S": {
+	"Nintendo Game Boy Advance - Retroarch(Flatpak) - VBA Next": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch(Flatpak) - Mesen-S",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch(Flatpak) - VBA Next",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mesen-s_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vba_next_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -518,7 +684,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -577,12 +743,344 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	},
-	"Nintendo GameBoy - Retroarch - mGBA": {
+	"Nintendo Game Boy Advance - Retroarch - VBA-M": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch - mGBA",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch - VBA-M",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vbam_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "${retroarchpath}",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Advance"
+		]
+	},
+	"Nintendo Game Boy Advance - Retroarch(Flatpak) - VBA-M": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch(Flatpak) - VBA-M",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vbam_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Advance"
+		]
+	},
+	"Nintendo Game Boy Advance - Retroarch - gpSP": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch - gpSP",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gpsp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.gba|.GBA|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "${retroarchpath}",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"GameB oy Advance"
+		]
+	},
+	"Nintendo Game Boy Advance - Retroarch(Flatpak) - gpSP": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch(Flatpak) - gpSP",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gpsp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.gba|.GBA|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"GameBoy Advance"
+		]
+	},
+	"Nintendo Game Boy Advance - Retroarch - mGBA": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch - mGBA",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -601,7 +1099,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -660,12 +1158,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	},
-	"Nintendo GameBoy - Retroarch(Flatpak) - mGBA": {
+	"Nintendo Game Boy Advance - Retroarch(Flatpak) - mGBA": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch(Flatpak) - mGBA",
+		"configTitle": "Nintendo Game Boy Advance - Retroarch(Flatpak) - mGBA",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -684,7 +1182,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -743,339 +1241,7 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
-		]
-	},
-	"Nintendo GameBoy - Retroarch - SameBoy": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch - SameBoy",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}sameboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": "${${fuzzyTitle}}",
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": "",
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "${retroarchpath}",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"GameBoy"
-		]
-	},
-	"Nintendo GameBoy - Retroarch(Flatpak) - SameBoy": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch(Flatpak) - SameBoy",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}sameboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": "${${fuzzyTitle}}",
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": "",
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"GameBoy"
-		]
-	},
-	"Nintendo GameBoy - Retroarch - TGB Dual": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch - TGB Dual",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}tgbdual_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": "${${fuzzyTitle}}",
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.sgb|.SGB|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": "",
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "${retroarchpath}",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"GameBoy"
-		]
-	},
-	"Nintendo GameBoy - Retroarch(Flatpak) - TGB Dual": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy - Retroarch(Flatpak) - TGB Dual",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}tgbdual_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": "${${fuzzyTitle}}",
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.sgb|.SGB|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": "",
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"GameBoy"
+			"Game Boy Advance"
 		]
 	}
 }

--- a/files/presets/Nintendo Game Boy Color.json
+++ b/files/presets/Nintendo Game Boy Color.json
@@ -1,7 +1,173 @@
 {
-	"Nintendo GameBoy Advance - mGBA(Flatpak)": {
+	"Nintendo Game Boy Color - ares": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - mGBA(Flatpak)",
+		"configTitle": "Nintendo Game Boy Color - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Game Boy Color\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gbc|.GBC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Color"
+		]
+	},
+	"Nintendo Game Boy Color - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Color - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy Color\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gbc|.GBC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Color"
+		]
+	},
+	"Nintendo Game Boy Color - mGBA(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Color - mGBA(Flatpak)",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -20,7 +186,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gbc|.GBC|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -79,18 +245,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy"
+			"Game Boy Color"
 		]
 	},
-	"Nintendo GameBoy Advance - Retroarch - Beetle GBA": {
+	"Nintendo Game Boy Color - Retroarch - Gambatte": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch - Beetle GBA",
+		"configTitle": "Nintendo Game Boy Color - Retroarch - Gambatte",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_gba_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gambatte_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -103,7 +269,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.agb|.AGB|.bin|.BIN|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -162,18 +328,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Advance"
+			"Game Boy Color"
 		]
 	},
-	"Nintendo GameBoy Advance - Retroarch(Flatpak) - Beetle GBA": {
+	"Nintendo Game Boy Color - Retroarch(Flatpak) - Gambatte": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch(Flatpak) - Beetle GBA",
+		"configTitle": "Nintendo Game Boy Color - Retroarch(Flatpak) - Gambatte",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mednafen_gba_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gambatte_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -186,7 +352,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.agb|.AGB|.bin|.BIN|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -245,18 +411,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Advance"
+			"Game Boy Color"
 		]
 	},
-	"Nintendo GameBoy Advance - Retroarch - Meteor": {
+	"Nintendo Game Boy Color - Retroarch - Gearboy": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch - Meteor",
+		"configTitle": "Nintendo Game Boy Color - Retroarch - Gearboy",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}meteor_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gearboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -269,7 +435,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.dmg|.DMG|.sgb|.SGB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -328,18 +494,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Advance"
+			"Game Boy Color"
 		]
 	},
-	"Nintendo GameBoy Advance - Retroarch(Flatpak) - Meteor": {
+	"Nintendo Game Boy Color - Retroarch(Flatpak) - Gearboy": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch(Flatpak) - Meteor",
+		"configTitle": "Nintendo Game Boy Color - Retroarch(Flatpak) - Gearboy",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}meteor_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gearboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -352,7 +518,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.dmg|.DMG|.sgb|.SGB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -411,18 +577,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Advance"
+			"Game Boy Color"
 		]
 	},
-	"Nintendo GameBoy Advance - Retroarch - VBA Next": {
+	"Nintendo Game Boy Color - Retroarch - Mesen-S": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch - VBA Next",
+		"configTitle": "Nintendo Game Boy Color - Retroarch - Mesen-S",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vba_next_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mesen-s_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -435,7 +601,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -494,18 +660,18 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Advance"
+			"Game Boy Color"
 		]
 	},
-	"Nintendo GameBoy Advance - Retroarch(Flatpak) - VBA Next": {
+	"Nintendo Game Boy Color - Retroarch(Flatpak) - Mesen-S": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch(Flatpak) - VBA Next",
+		"configTitle": "Nintendo Game Boy Color - Retroarch(Flatpak) - Mesen-S",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
 		"startInDirectory": "",
 		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vba_next_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}mesen-s_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
 		"onlineImageQueries": "${${fuzzyTitle}}",
 		"imagePool": "${fuzzyTitle}",
 		"imageProviders": [
@@ -518,7 +684,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -577,344 +743,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Advance"
+			"Game Boy Color"
 		]
 	},
-	"Nintendo GameBoy Advance - Retroarch - VBA-M": {
+	"Nintendo Game Boy Color - Retroarch - mGBA": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch - VBA-M",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vbam_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": "${${fuzzyTitle}}",
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": "",
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "${retroarchpath}",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"GameBoy Advance"
-		]
-	},
-	"Nintendo GameBoy Advance - Retroarch(Flatpak) - VBA-M": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch(Flatpak) - VBA-M",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}vbam_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": "${${fuzzyTitle}}",
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": "",
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"GameBoy Advance"
-		]
-	},
-	"Nintendo GameBoy Advance - Retroarch - gpSP": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch - gpSP",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gpsp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": "${${fuzzyTitle}}",
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.gba|.GBA|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": "",
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "${retroarchpath}",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"GameBoy Advance"
-		]
-	},
-	"Nintendo GameBoy Advance - Retroarch(Flatpak) - gpSP": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch(Flatpak) - gpSP",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}gpsp_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": "${${fuzzyTitle}}",
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.gba|.GBA|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": "",
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"GameBoy Advance"
-		]
-	},
-	"Nintendo GameBoy Advance - Retroarch - mGBA": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch - mGBA",
+		"configTitle": "Nintendo Game Boy Color - Retroarch - mGBA",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -933,7 +767,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -992,12 +826,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Advance"
+			"Game Boy Color"
 		]
 	},
-	"Nintendo GameBoy Advance - Retroarch(Flatpak) - mGBA": {
+	"Nintendo Game Boy Color - Retroarch(Flatpak) - mGBA": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Advance - Retroarch(Flatpak) - mGBA",
+		"configTitle": "Nintendo Game Boy Color - Retroarch(Flatpak) - mGBA",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -1016,7 +850,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -1075,7 +909,339 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Advance"
+			"Game Boy Color"
+		]
+	},
+	"Nintendo Game Boy Color - Retroarch - SameBoy": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Color - Retroarch - SameBoy",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}sameboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "${retroarchpath}",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Color"
+		]
+	},
+	"Nintendo Game Boy Color - Retroarch(Flatpak) - SameBoy": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Color - Retroarch(Flatpak) - SameBoy",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}sameboy_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Color"
+		]
+	},
+	"Nintendo Game Boy Color - Retroarch - TGB Dual": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Color - Retroarch - TGB Dual",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}tgbdual_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.sgb|.SGB|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "${retroarchpath}",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Color"
+		]
+	},
+	"Nintendo Game Boy Color - Retroarch(Flatpak) - TGB Dual": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy Color - Retroarch(Flatpak) - TGB Dual",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run org.libretro.RetroArch -L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}tgbdual_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.sgb|.SGB|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy Color"
 		]
 	}
 }

--- a/files/presets/Nintendo Game Boy.json
+++ b/files/presets/Nintendo Game Boy.json
@@ -1,7 +1,173 @@
 {
-	"Nintendo GameBoy Color - mGBA(Flatpak)": {
+	"Nintendo Game Boy - ares": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - mGBA(Flatpak)",
+		"configTitle": "Nintendo Game Boy - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Game Boy\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy"
+		]
+	},
+	"Nintendo Game Boy - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Boy"
+		]
+	},
+	"Nintendo Game Boy - mGBA(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo Game Boy - mGBA(Flatpak)",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -20,7 +186,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -79,12 +245,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch - Gambatte": {
+	"Nintendo Game Boy - Retroarch - Gambatte": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch - Gambatte",
+		"configTitle": "Nintendo Game Boy - Retroarch - Gambatte",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -103,7 +269,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -162,12 +328,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch(Flatpak) - Gambatte": {
+	"Nintendo Game Boy - Retroarch(Flatpak) - Gambatte": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch(Flatpak) - Gambatte",
+		"configTitle": "Nintendo Game Boy - Retroarch(Flatpak) - Gambatte",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -186,7 +352,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -245,12 +411,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch - Gearboy": {
+	"Nintendo Game Boy - Retroarch - Gearboy": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch - Gearboy",
+		"configTitle": "Nintendo Game Boy - Retroarch - Gearboy",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -269,7 +435,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.dmg|.DMG|.sgb|.SGB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.sgb|.SGB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -328,12 +494,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch(Flatpak) - Gearboy": {
+	"Nintendo Game Boy - Retroarch(Flatpak) - Gearboy": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch(Flatpak) - Gearboy",
+		"configTitle": "Nintendo Game Boy - Retroarch(Flatpak) - Gearboy",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -352,7 +518,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.dmg|.DMG|.sgb|.SGB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.dmg|.DMG|.sgb|.SGB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -411,12 +577,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch - Mesen-S": {
+	"Nintendo Game Boy - Retroarch - Mesen-S": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch - Mesen-S",
+		"configTitle": "Nintendo Game Boy - Retroarch - Mesen-S",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -435,7 +601,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -494,12 +660,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch(Flatpak) - Mesen-S": {
+	"Nintendo Game Boy - Retroarch(Flatpak) - Mesen-S": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch(Flatpak) - Mesen-S",
+		"configTitle": "Nintendo Game Boy - Retroarch(Flatpak) - Mesen-S",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -518,7 +684,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -577,12 +743,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch - mGBA": {
+	"Nintendo Game Boy - Retroarch - mGBA": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch - mGBA",
+		"configTitle": "Nintendo Game Boy - Retroarch - mGBA",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -601,7 +767,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -660,12 +826,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch(Flatpak) - mGBA": {
+	"Nintendo Game Boy - Retroarch(Flatpak) - mGBA": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch(Flatpak) - mGBA",
+		"configTitle": "Nintendo Game Boy - Retroarch(Flatpak) - mGBA",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -684,7 +850,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -743,12 +909,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch - SameBoy": {
+	"Nintendo Game Boy - Retroarch - SameBoy": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch - SameBoy",
+		"configTitle": "Nintendo Game Boy - Retroarch - SameBoy",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -767,7 +933,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -826,12 +992,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch(Flatpak) - SameBoy": {
+	"Nintendo Game Boy - Retroarch(Flatpak) - SameBoy": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch(Flatpak) - SameBoy",
+		"configTitle": "Nintendo Game Boy - Retroarch(Flatpak) - SameBoy",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -850,7 +1016,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -909,12 +1075,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch - TGB Dual": {
+	"Nintendo Game Boy - Retroarch - TGB Dual": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch - TGB Dual",
+		"configTitle": "Nintendo Game Boy - Retroarch - TGB Dual",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -933,7 +1099,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.sgb|.SGB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.sgb|.SGB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -992,12 +1158,12 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	},
-	"Nintendo GameBoy Color - Retroarch(Flatpak) - TGB Dual": {
+	"Nintendo Game Boy - Retroarch(Flatpak) - TGB Dual": {
 		"parserType": "Glob",
-		"configTitle": "Nintendo GameBoy Color - Retroarch(Flatpak) - TGB Dual",
+		"configTitle": "Nintendo Game Boy - Retroarch(Flatpak) - TGB Dual",
 		"executableModifier": "\"${exePath}\"",
 		"romDirectory": "path-to-roms",
 		"steamDirectory": "${steamdirglobal}",
@@ -1016,7 +1182,7 @@
 			]
 		},
 		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.gbc|.GBC|.sgb|.SGB|.zip|.ZIP)"
+			"glob": "${title}@(.7z|.7Z|.gb|.GB|.sgb|.SGB|.zip|.ZIP)"
 		},
 		"titleFromVariable": {
 			"limitToGroups": "",
@@ -1075,7 +1241,7 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"GameBoy Color"
+			"Game Boy"
 		]
 	}
 }

--- a/files/presets/Nintendo GameCube.json
+++ b/files/presets/Nintendo GameCube.json
@@ -79,7 +79,7 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"Gamecube"
+			"GameCube"
 		]
 	},
 	"Nintendo GameCube - Dolphin(Flatpak)": {
@@ -162,7 +162,7 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"Gamecube"
+			"GameCube"
 		]
 	},
 	"Nintendo GameCube - Retroarch - Dolphin": {
@@ -245,7 +245,7 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"Gamecube"
+			"GameCube"
 		]
 	},
 	"Nintendo GameCube - Retroarch(Flatpak) - Dolphin": {
@@ -328,7 +328,7 @@
 		"steamInputEnabled": "1",
 		"drmProtect": false,
 		"steamCategories": [
-			"Gamecube"
+			"GameCube"
 		]
 	}
 }

--- a/files/presets/Nintendo NES.json
+++ b/files/presets/Nintendo NES.json
@@ -1,4 +1,170 @@
 {
+	"Nintendo NES - ares": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo NES - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Famicom\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"NES"
+		]
+	},
+	"Nintendo NES - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo NES - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Famicom\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"NES"
+		]
+	},
 	"Nintendo NES - Nestopia UE(Flatpak)": {
 		"parserType": "Glob",
 		"configTitle": "Nintendo NES - Nestopia UE(Flatpak)",

--- a/files/presets/Nintendo SNES.json
+++ b/files/presets/Nintendo SNES.json
@@ -1,4 +1,170 @@
 {
+	"Nintendo SNES - ares": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo SNES - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Super Famicom\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bs|.BS|.sfc|.SFC|.smc|.SMC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"SNES"
+		]
+	},
+	"Nintendo SNES - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Nintendo SNES - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Super Famicom\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bs|.BS|.sfc|.SFC|.smc|.SMC|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"SNES"
+		]
+	},
 	"Nintendo SNES - bsnes(Flatpak)": {
 		"parserType": "Glob",
 		"configTitle": "Nintendo SNES - bsnes(Flatpak)",

--- a/files/presets/Sega 32X.json
+++ b/files/presets/Sega 32X.json
@@ -1,4 +1,170 @@
 {
+	"Sega 32X - ares": {
+		"parserType": "Glob",
+		"configTitle": "Sega 32X - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Mega 32X\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.32x|.32X|.bin|.BIN|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"32X"
+		]
+	},
+	"Sega 32X - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Sega 32X - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Mega 32X\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.32x|.32X|.bin|.BIN|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"32X"
+		]
+	},
 	"Sega 32X - Retroarch - PicoDrive": {
 		"parserType": "Glob",
 		"configTitle": "Sega 32X - Retroarch - PicoDrive",

--- a/files/presets/Sega CD+Mega CD.json
+++ b/files/presets/Sega CD+Mega CD.json
@@ -1,4 +1,170 @@
 {
+	"Sega CD/Mega CD - ares": {
+		"parserType": "Glob",
+		"configTitle": "Sega CD/Mega CD - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Mega CD\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.iso|.ISO|.cue|.CUE|.chd|.CHD|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Sega CD/Mega CD"
+		]
+	},
+	"Sega CD/Mega CD - ares (Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Sega CD/Mega CD - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Mega CD\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.iso|.ISO|.cue|.CUE|.chd|.CHD|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Sega CD/Mega CD"
+		]
+	},
 	"Sega CD/Mega CD - Retroarch - Genesis Plus GX": {
 		"parserType": "Glob",
 		"configTitle": "Sega CD/Mega CD - Retroarch - Genesis Plus GX",

--- a/files/presets/Sega Game Gear.json
+++ b/files/presets/Sega Game Gear.json
@@ -1,4 +1,170 @@
 {
+	"Sega Game Gear - ares": {
+		"parserType": "Glob",
+		"configTitle": "Sega Game Gear - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Game Gear\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.gg|.GG|.rom|.ROM|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Gear"
+		]
+	},
+	"Sega Game Gear - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Sega Game Gear - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Game Gear\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.gg|.GG|.rom|.ROM|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Game Gear"
+		]
+	},
 	"Sega Game Gear - Retroarch - Gearsystem": {
 		"parserType": "Glob",
 		"configTitle": "Sega Game Gear - Retroarch - Gearsystem",

--- a/files/presets/Sega Genesis+Mega Drive.json
+++ b/files/presets/Sega Genesis+Mega Drive.json
@@ -1,4 +1,170 @@
 {
+	"Sega Genesis/Mega Drive - ares": {
+		"parserType": "Glob",
+		"configTitle": "Sega Genesis/Mega Drive - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Mega Drive\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.bin|.BIN)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Genesis/Mega Drive"
+		]
+	},
+	"Sega Genesis/Mega Drive - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Sega Genesis/Mega Drive - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Mega Drive\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.bin|.BIN)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Genesis/Mega Drive"
+		]
+	},
 	"Sega Genesis/Mega Drive - Retroarch - Genesis Plus GX": {
 		"parserType": "Glob",
 		"configTitle": "Sega Genesis/Mega Drive - Retroarch - Genesis Plus GX",

--- a/files/presets/Sega Master System.json
+++ b/files/presets/Sega Master System.json
@@ -1,4 +1,170 @@
 {
+	"Sega Master System - ares": {
+		"parserType": "Glob",
+		"configTitle": "Sega Master System - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"Master System\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.rom|.ROM|.sms|.SMS|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Master System"
+		]
+	},
+	"Sega Master System - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Sega Master System - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"Master System\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.rom|.ROM|.sms|.SMS|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"Master System"
+		]
+	},
 	"Sega Master System - Retroarch - Gearsystem": {
 		"parserType": "Glob",
 		"configTitle": "Sega Master System - Retroarch - Gearsystem",

--- a/files/presets/Sega SG-1000.json
+++ b/files/presets/Sega SG-1000.json
@@ -1,4 +1,170 @@
 {
+	"Sega SG-1000 - ares": {
+		"parserType": "Glob",
+		"configTitle": "Sega SG-1000 - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"SG-1000\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.ri|.RI|.rom|.ROM|.sg|.SG|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"SG-1000"
+		]
+	},
+	"Sega SG-1000 - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Sega SG-1000 - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"SG-1000\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.ri|.RI|.rom|.ROM|.sg|.SG|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"SG-1000"
+		]
+	},
 	"Sega SG-1000 - Retroarch - BlueMSX": {
 		"parserType": "Glob",
 		"configTitle": "Sega SG-1000 - Retroarch - BlueMSX",

--- a/files/presets/Sinclair ZX Spectrum.json
+++ b/files/presets/Sinclair ZX Spectrum.json
@@ -1,0 +1,168 @@
+{
+	"Sinclair ZX Spectrum  - ares": {
+		"parserType": "Glob",
+		"configTitle": "Sinclair ZX Spectrum - ares",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "--fullscreen --system \"ZX Spectrum\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.dsk|.DSK|.gz|.GZ|.img|.IMG|.mgt|.MGT|.rzx|.RZX|.scl|.SCL|.sh|.SH|.sna|.SNA|.szx|.SZX|.tap|.TAP|.trd|.TRD|.tzx|.TZX|.udi|.UDI|.z80|.Z80|.7z|.7Z|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "path-to-ares.exe",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"ZX Spectrum"
+		]
+	},
+	"Sinclair ZX Spectrum  - ares(Flatpak)": {
+		"parserType": "Glob",
+		"configTitle": "Sinclair ZX Spectrum - ares(Flatpak)",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "run dev.ares.ares --fullscreen --system \"ZX Spectrum\" \"${filePath}\"",
+		"onlineImageQueries": "${${fuzzyTitle}}",
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.dsk|.DSK|.gz|.GZ|.img|.IMG|.mgt|.MGT|.rzx|.RZX|.scl|.SCL|.sh|.SH|.sna|.SNA|.szx|.SZX|.tap|.TAP|.trd|.TRD|.tzx|.TZX|.udi|.UDI|.z80|.Z80|.7z|.7Z|.zip|.ZIP)"
+		},
+		"titleFromVariable": {
+			"limitToGroups": "",
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "/usr/bin/flatpak",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 17,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			},
+			"steamCDN": {}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"ZX Spectrum"
+		]
+	}
+}


### PR DESCRIPTION
* Added the following ares systems: 
    * Atari 2600, Bandai Wanderswan, Bandai Wanderswan Color, Benesse Pocket Challenge V2, Coleco ColecoVision, Microsoft MSX, Microsoft MSX 2, NEC PC Engine CD+TurboGrafx CD, NEC PC Engine SuperGrafx, NEC PC Engine+TurboGrafx 16, Nintendo Game Boy Advance, Nintendo Game Boy Color, Nintendo Game Boy, Nintendo NES, Sega 32X, Sega CD+Mega CD, Sega Game Gear, Sega Genesis+Mega Drive.Sega Master System, /Sega SG-1000, and Sinclair ZX Spectrum
* Cosmetic: 
    * Updated the GB family to add a space between "Game" and "Boy" 
    * Updated the GC Steam category name to "GameCube" from "Gamecube" 
    * Updated the GBA preset file to use "Game Boy Advance" for all presets (some were using "GameBoy", some were using "GameBoy Advance")

Minor issue, but there is some inconsistency with the Steam category names:
  * The GB family uses spelled out "Game Boy", "Game Boy Advance", and so on. The other systems use acronyms. I personally prefer the spelled out approach, but regardless of my opinion, I think it'd be good to have some sort of consistency using either format. 
  * Regional differences are included for the NEC family and the Sega CD but not the NES and the SNES (Famicom and Super Famicom in Japan). 

With the addition of the Bandai Wanderswan in this PR, there's also the issue with the SNK Neo Geo Pocket and SNK Neo Geo Pocket Color being combined into one preset. I split these for the Bandai, but ares supports the SNK NGP duo as well but has separate system names for both. Should the SNK NGP preset be split like the Bandai one?