### PR TITLE
presets: adding Sony PlayStation - Retroarch - SwanStation

### DIFF
--- a/files/presets/Sony PlayStation.json
+++ b/files/presets/Sony PlayStation.json
@@ -448,5 +448,89 @@
     "steamInputEnabled": "1",
     "drmProtect": false,
     "steamCategories": ["PS1"]
-  }
+  },
+  "Sony PlayStation - Retroarch - SwanStation": {
+		"parserType": "Glob",
+		"configTitle": "Sony PlayStation - Retroarch - SwanStation",
+		"executableModifier": "\"${exePath}\"",
+		"romDirectory": "path-to-roms",
+		"steamDirectory": "${steamdirglobal}",
+		"startInDirectory": "",
+		"titleModifier": "${fuzzyTitle}",
+		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}swanstation_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+		"onlineImageQueries": [
+			"${fuzzyTitle}"
+		],
+		"imagePool": "${fuzzyTitle}",
+		"imageProviders": [
+			"sgdb"
+		],
+		"disabled": false,
+		"userAccounts": {
+			"specifiedAccounts": [
+				"Global"
+			]
+		},
+		"parserInputs": {
+			"glob": "${title}@(.7z|.7Z|.chd|.CHD|.cue|.CUE|.ecm|.ECM|.exe|.EXE|.img|.IMG|.iso|.ISO|.m3u|.M3U|.mds|.MDS|.pbp|.PBP|.psexe|.PSEXE|.psf|.PSF)"
+		},
+		"titleFromVariable": {
+			"caseInsensitiveVariables": false,
+			"skipFileIfVariableWasNotFound": false,
+			"limitToGroups": []
+		},
+		"fuzzyMatch": {
+			"replaceDiacritics": true,
+			"removeCharacters": true,
+			"removeBrackets": true
+		},
+		"executable": {
+			"path": "${retroarchpath}",
+			"shortcutPassthrough": false,
+			"appendArgsToExecutable": true
+		},
+		"presetVersion": 19,
+		"imageProviderAPIs": {
+			"sgdb": {
+				"nsfw": false,
+				"humor": false,
+				"imageMotionTypes": [
+					"static"
+				],
+				"styles": [],
+				"stylesHero": [],
+				"stylesLogo": [],
+				"stylesIcon": []
+			}
+		},
+		"controllers": {
+			"ps4": null,
+			"ps5": null,
+			"xbox360": null,
+			"xboxone": null,
+			"switch_joycon_left": null,
+			"switch_joycon_right": null,
+			"switch_pro": null,
+			"neptune": null
+		},
+		"defaultImage": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"localImages": {
+			"long": "",
+			"tall": "",
+			"hero": "",
+			"logo": "",
+			"icon": ""
+		},
+		"steamInputEnabled": "1",
+		"drmProtect": false,
+		"steamCategories": [
+			"PS1"
+		]
+	}
 }


### PR DESCRIPTION
Adding a preset for the following PSX Retroarch core: https://github.com/libretro/swanstation

(Let me know in case I've missed other required files)