### PR TITLE
Fix: Await file promises when reading controller user templates

### DIFF
--- a/src/lib/controller-manager.ts
+++ b/src/lib/controller-manager.ts
@@ -98,14 +98,18 @@ export class ControllerManager {
       cwd: templateDirUser,
       absolute: true,
     });
-    let parsedTemplatesUser: ControllerTemplate[] = filesUser
-      .filter((f: string) => fs.lstatSync(f).isFile())
-      .map(async (f: string) =>
-        Object.assign(
-          { mappingId: f.split(path.sep).slice(-2)[0] },
-          genericParser.parse(await fs.readFile(f, "utf-8")),
-        ),
+    let parsedTemplatesUser: ControllerTemplate[] = (
+      await Promise.all(
+        filesUser
+          .filter((f: string) => fs.lstatSync(f).isFile())
+          .map(async (f: string) =>
+            Object.assign(
+              { mappingId: f.split(path.sep).slice(-2)[0] },
+              genericParser.parse(await fs.readFile(f, "utf-8")),
+            ),
+          ),
       )
+    )
       .filter(
         (x: any) =>
           !!x["controller_mappings"] &&


### PR DESCRIPTION
The commit 7620d9e208e84acfaa5d70e3f93139509659010a introduced async reading of controller user template files.
However, the promises were never resolved, leading to every user template being filtered out by the subsequent filter.

This PR fixes that by wrapping the mapping in a `Promise.all` call.

Likely closes #722.