### PR TITLE
Presets: Adds a new preset for RPCS3 to support PlayStation 3 ISO files

### DIFF
--- a/files/presets/Sony PlayStation 3.json
+++ b/files/presets/Sony PlayStation 3.json
@@ -1,4 +1,79 @@
 {
+  "Sony PlayStation 3 - RPCS3 (ISO)": {
+    "parserType": "Glob",
+    "configTitle": "Sony PlayStation 3 - RPCS3 (ISO)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--no-gui \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.iso|.ISO)"
+    },
+    "titleFromVariable": {
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "limitToGroups": ["PS3"]
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-rpcs3",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 19,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PS3"]
+  },
   "Sony PlayStation 3 - RPCS3 (Extracted ISO)": {
     "parserType": "Glob",
     "configTitle": "Sony PlayStation 3 - RPCS3 (Extracted ISO)",


### PR DESCRIPTION
As you may already know, RPCS3 finally supports decrypted ISO images. This preset adds support for them.

Closes https://github.com/SteamGridDB/steam-rom-manager/issues/786