### PR TITLE
Categories: Fix "Cannot read properties of undefined (reading 'filter')"

### DIFF
--- a/src/lib/category-manager.ts
+++ b/src/lib/category-manager.ts
@@ -85,7 +85,7 @@ export class CategoryManager {
         cloudData.forEach((item: any) => {
           if (item && item[0] && item[0].startsWith('user-collections.')) {
             const collectionId = item[0].replace('user-collections.', '');
-            if (!item[1].is_deleted && item[1].value) {
+            if (!item[1].is_deleted && JSON.parse(item[1].value).added) {
               try {
                 collections[collectionId] = JSON.parse(item[1].value);
                 if (collectionId.startsWith('srm-')) {


### PR DESCRIPTION
There is a "partner-ea-access" collection in steam is missing the "added" attribute so when SRM goes to filter the list of games added to a collection the process fails. I assume if you have games that steam considers ea-access then it would have the attribute.

SRM doesn't need to handle this collection or similar collections since as far as I can tell they are invalid.